### PR TITLE
ci: add action to automatically sync README to Docker Hub

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,3 +125,18 @@ jobs:
           docker buildx imagetools create -t ${{ secrets.DOCKERHUB_USERNAME }}/esp32-photoframe-server:${{ steps.version.outputs.VERSION }} \
             ${{ secrets.DOCKERHUB_USERNAME }}/esp32-photoframe-server:${{ steps.version.outputs.VERSION }}-amd64 \
             ${{ secrets.DOCKERHUB_USERNAME }}/esp32-photoframe-server:${{ steps.version.outputs.VERSION }}-arm64
+
+  update-readme:
+    name: Update Docker Hub README
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Sync README to Docker Hub
+        uses: peter-evans/dockerhub-description@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          repository: ${{ secrets.DOCKERHUB_USERNAME }}/esp32-photoframe-server
+          short-description: "Image server for ESP32 PhotoFrame: Google Photos, Synology, Telegram & AI generation."


### PR DESCRIPTION
Hi!

I noticed that the Docker images on Docker Hub currently don't have a description or README displayed. 

This PR adds a new job `update-readme` to the `ci.yml` workflow. It automatically syncs the repository's `README.md` to Docker Hub whenever there is a push to `main` or a new tag is created. 

It uses the standard `peter-evans/dockerhub-description` action and reuses your already existing repository secrets (`DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN`). It will work right out of the box without any additional setup required from your side.

Best regards!