### PR TITLE
Add Immich support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A image server for the [ESP32 PhotoFrame](https://github.com/aitjcize/esp32-phot
     - **Telegram Bot**: Send photos directly to your frame via a Telegram bot.
     - **URL Proxy**: Display images from any URL.
     - **AI Generation**: Generate unique images using OpenAI (GPT Image, DALL-E) or Google Gemini.
+    - **Immich Photos**: Serve random photos directly from an [Immich](https://immich.app/) server (no import needed).
 - **Smart Image Processing**:
     - Automatic cropping to device aspect ratio (800x480 or 480x800).
     - **Smart Collage**: Automatically combines two landscape photos in portrait mode (or vice versa) to maximize screen usage.
@@ -153,6 +154,15 @@ Access the dashboard at `http://localhost:9607` (or your server IP, or via Home 
 3. Add URLs to images you want to display.
 4. Assign URLs to specific devices.
 
+### Immich Setup
+
+1. Go to **Settings** → **Data Sources** → **Immich**.
+2. Enter your **Immich Server URL** (e.g., `http://192.168.1.100:2283`).
+3. Generate an API key in your Immich instance: **User Settings** → **API Keys** → Create.
+4. Enter the **API Key** and click **Test Connection & Save**.
+5. Optionally select a specific **Album** to pick random photos from.
+6. Photos are fetched directly from Immich on each request — no import or sync needed.
+
 ### AI Generation Setup
 
 Generate unique AI artwork for your photo frame using OpenAI or Google Gemini.
@@ -199,6 +209,7 @@ http(s)://<hostname/IP address>:9607/image/<source>
 - **`GET /image/telegram`**: Returns the last photo sent via **Telegram Bot**.
 - **`GET /image/url_proxy`**: Returns a random image from configured URLs.
 - **`GET /image/ai_generation`**: Returns a newly generated AI image based on device prompt.
+- **`GET /image/immich_photos`**: Returns a random image from a connected Immich server.
 
 ### Authentication
 

--- a/backend/internal/handler/image.go
+++ b/backend/internal/handler/image.go
@@ -37,6 +37,7 @@ type ImageHandlerDeps struct {
 	CalendarGoogle *googlephotos.Client
 	Synology       *service.SynologyService
 	AIGen          *service.AIGenerationService
+	Immich         *service.ImmichService
 	Weather        *weather.Client
 	Calendar       *gcalendar.Client
 	DB             *gorm.DB
@@ -51,6 +52,7 @@ type ImageHandler struct {
 	calendarGoogle *googlephotos.Client
 	synology       *service.SynologyService
 	aiGen          *service.AIGenerationService
+	immich         *service.ImmichService
 	weather        *weather.Client
 	calendar       *gcalendar.Client
 	db             *gorm.DB
@@ -66,6 +68,7 @@ func NewImageHandler(deps ImageHandlerDeps) *ImageHandler {
 		calendarGoogle: deps.CalendarGoogle,
 		synology:       deps.Synology,
 		aiGen:          deps.AIGen,
+		immich:         deps.Immich,
 		weather:        deps.Weather,
 		calendar:       deps.Calendar,
 		db:             deps.DB,
@@ -210,6 +213,9 @@ func (h *ImageHandler) ServeImage(c echo.Context) error {
 			return c.JSON(http.StatusBadRequest, map[string]string{"error": "device not found - AI generation requires device config"})
 		}
 		img, err = h.aiGen.Generate(&device)
+	} else if source == model.SourceImmichPhotos {
+		// Immich Photos: fetch random photo directly from Immich API
+		img, err = h.immich.FetchRandomPhoto()
 	} else if enableCollage {
 		var devID *uint
 		if deviceFound {
@@ -621,6 +627,9 @@ func (h *ImageHandler) applySourceFilter(query *gorm.DB, sourceFilter string, de
 		return query.Where("source = ?", sourceFilter), nil, nil
 	case model.SourceURLProxy:
 		img, _, err := h.fetchRandomURLProxy(deviceID)
+		return nil, img, err
+	case model.SourceImmichPhotos:
+		img, err := h.immich.FetchRandomPhoto()
 		return nil, img, err
 	default:
 		return nil, nil, fmt.Errorf("invalid source filter: %s", sourceFilter)

--- a/backend/internal/handler/immich.go
+++ b/backend/internal/handler/immich.go
@@ -1,0 +1,61 @@
+package handler
+
+import (
+	"net/http"
+
+	"github.com/aitjcize/esp32-photoframe-server/backend/internal/service"
+	"github.com/labstack/echo/v4"
+)
+
+// ImmichHandler handles Immich-related API requests.
+type ImmichHandler struct {
+	immich *service.ImmichService
+}
+
+// NewImmichHandler creates a new ImmichHandler.
+func NewImmichHandler(immich *service.ImmichService) *ImmichHandler {
+	return &ImmichHandler{immich: immich}
+}
+
+// TestConnection tests the connection to an Immich server.
+func (h *ImmichHandler) TestConnection(c echo.Context) error {
+	var req struct {
+		ServerURL string `json:"server_url"`
+		APIKey    string `json:"api_key"`
+	}
+	if err := c.Bind(&req); err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "invalid request"})
+	}
+
+	if req.ServerURL == "" || req.APIKey == "" {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "server_url and api_key are required"})
+	}
+
+	if err := h.immich.TestConnection(req.ServerURL, req.APIKey); err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": err.Error()})
+	}
+
+	return c.JSON(http.StatusOK, map[string]string{"status": "ok"})
+}
+
+// ListAlbums returns a list of albums from the configured Immich server.
+func (h *ImmichHandler) ListAlbums(c echo.Context) error {
+	var req struct {
+		ServerURL string `json:"server_url"`
+		APIKey    string `json:"api_key"`
+	}
+	if err := c.Bind(&req); err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "invalid request"})
+	}
+
+	if req.ServerURL == "" || req.APIKey == "" {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "server_url and api_key are required"})
+	}
+
+	albums, err := h.immich.ListAlbums(req.ServerURL, req.APIKey)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+	}
+
+	return c.JSON(http.StatusOK, albums)
+}

--- a/backend/internal/model/model.go
+++ b/backend/internal/model/model.go
@@ -17,6 +17,7 @@ const (
 	SourceTelegram       = "telegram"
 	SourceURLProxy       = "url_proxy"
 	SourceAIGeneration   = "ai_generation"
+	SourceImmichPhotos   = "immich_photos"
 )
 
 type Image struct {

--- a/backend/internal/service/immich.go
+++ b/backend/internal/service/immich.go
@@ -1,0 +1,81 @@
+package service
+
+import (
+	"bytes"
+	"fmt"
+	"image"
+	_ "image/jpeg"
+	_ "image/png"
+	"log"
+
+	"github.com/aitjcize/esp32-photoframe-server/backend/pkg/immich"
+)
+
+// ImmichService manages interaction with an Immich server.
+type ImmichService struct {
+	settings *SettingsService
+	client   *immich.Client
+}
+
+// NewImmichService creates a new ImmichService.
+func NewImmichService(settings *SettingsService) *ImmichService {
+	return &ImmichService{
+		settings: settings,
+		client:   immich.NewClient(),
+	}
+}
+
+// getConfig fetches the current Immich configuration from settings.
+func (s *ImmichService) getConfig() (serverURL, apiKey, albumID string, err error) {
+	serverURL, err = s.settings.Get("immich_url")
+	if err != nil || serverURL == "" {
+		return "", "", "", fmt.Errorf("immich_url not configured")
+	}
+	apiKey, err = s.settings.Get("immich_api_key")
+	if err != nil || apiKey == "" {
+		return "", "", "", fmt.Errorf("immich_api_key not configured")
+	}
+	albumID, _ = s.settings.Get("immich_album_id")
+	return serverURL, apiKey, albumID, nil
+}
+
+// TestConnection tests the connection to the Immich server.
+func (s *ImmichService) TestConnection(serverURL, apiKey string) error {
+	return s.client.TestConnection(serverURL, apiKey)
+}
+
+// ListAlbums returns all albums from the configured Immich server.
+func (s *ImmichService) ListAlbums(serverURL, apiKey string) ([]immich.Album, error) {
+	return s.client.ListAlbums(serverURL, apiKey)
+}
+
+// FetchRandomPhoto fetches a random photo from the configured Immich server/album
+// and returns it as a decoded image.
+func (s *ImmichService) FetchRandomPhoto() (image.Image, error) {
+	serverURL, apiKey, albumID, err := s.getConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	// Get a random asset
+	asset, err := s.client.GetRandomAsset(serverURL, apiKey, albumID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get random asset: %w", err)
+	}
+
+	log.Printf("Immich: fetching asset %s (%s)", asset.ID, asset.OriginalFileName)
+
+	// Download the original file
+	data, err := s.client.DownloadAsset(serverURL, apiKey, asset.ID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to download asset: %w", err)
+	}
+
+	// Decode the image
+	img, _, err := image.Decode(bytes.NewReader(data))
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode image from Immich asset %s: %w", asset.ID, err)
+	}
+
+	return img, nil
+}

--- a/backend/main.go
+++ b/backend/main.go
@@ -167,6 +167,8 @@ func main() {
 	synologyService := service.NewSynologyService(database, settingsService)
 	// Initialize AI Generation Service
 	aiGenerationService := service.NewAIGenerationService(settingsService)
+	// Initialize Immich Service
+	immichService := service.NewImmichService(settingsService)
 
 	// Initialize Picker Service
 	// dataDir already set from migration logic above
@@ -220,6 +222,7 @@ func main() {
 		CalendarGoogle: googleCalendarClient,
 		Synology:       synologyService,
 		AIGen:          aiGenerationService,
+		Immich:         immichService,
 		Weather:        weatherClient,
 		Calendar:       calendarClient,
 		DB:             database,
@@ -227,6 +230,7 @@ func main() {
 	})
 	ch := handler.NewCalendarHandler(googleCalendarClient, calendarClient)
 	ah := handler.NewAuthHandler(authService)
+	imh := handler.NewImmichHandler(immichService)
 
 	// Echo instance
 	e := echo.New()
@@ -315,6 +319,10 @@ func main() {
 
 	// Calendar (Protected)
 	protectedApi.GET("/calendar/calendars", ch.ListCalendars)
+
+	// Immich (Protected)
+	protectedApi.POST("/immich/test", imh.TestConnection)
+	protectedApi.POST("/immich/albums", imh.ListAlbums)
 
 	// Google Auth (Photos + Calendar share the same callback via state parameter)
 	protectedApi.GET("/auth/google/login", googleHandler.Login)

--- a/backend/pkg/immich/immich.go
+++ b/backend/pkg/immich/immich.go
@@ -1,0 +1,168 @@
+package immich
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// Client communicates with an Immich server.
+type Client struct {
+	httpClient *http.Client
+}
+
+// Album represents an Immich album.
+type Album struct {
+	ID         string `json:"id"`
+	AlbumName  string `json:"albumName"`
+	AssetCount int    `json:"assetCount"`
+}
+
+// Asset represents an Immich asset (photo/video).
+type Asset struct {
+	ID               string `json:"id"`
+	Type             string `json:"type"` // "IMAGE" or "VIDEO"
+	OriginalFileName string `json:"originalFileName"`
+	OriginalMimeType string `json:"originalMimeType"`
+}
+
+// NewClient creates a new Immich API client.
+func NewClient() *Client {
+	return &Client{
+		httpClient: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+	}
+}
+
+// doRequest performs an authenticated request to the Immich API.
+func (c *Client) doRequest(method, serverURL, apiKey, path string, body io.Reader) (*http.Response, error) {
+	url := strings.TrimRight(serverURL, "/") + "/api" + path
+
+	req, err := http.NewRequest(method, url, body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("x-api-key", apiKey)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	req.Header.Set("Accept", "application/json")
+
+	return c.httpClient.Do(req)
+}
+
+// TestConnection verifies that we can connect to the Immich server with the given credentials.
+func (c *Client) TestConnection(serverURL, apiKey string) error {
+	resp, err := c.doRequest("GET", serverURL, apiKey, "/server/ping", nil)
+	if err != nil {
+		return fmt.Errorf("connection failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		bodyBytes, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("server returned status %d: %s", resp.StatusCode, string(bodyBytes))
+	}
+
+	return nil
+}
+
+// ListAlbums returns all albums from the Immich server.
+func (c *Client) ListAlbums(serverURL, apiKey string) ([]Album, error) {
+	resp, err := c.doRequest("GET", serverURL, apiKey, "/albums", nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list albums: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		bodyBytes, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("server returned status %d: %s", resp.StatusCode, string(bodyBytes))
+	}
+
+	var albums []Album
+	if err := json.NewDecoder(resp.Body).Decode(&albums); err != nil {
+		return nil, fmt.Errorf("failed to decode albums: %w", err)
+	}
+
+	return albums, nil
+}
+
+// GetRandomAsset fetches a random image asset from the Immich server.
+// If albumID is provided, filters to that album. Only returns IMAGE type assets.
+func (c *Client) GetRandomAsset(serverURL, apiKey, albumID string) (*Asset, error) {
+	// Build the search/random request body
+	reqBody := map[string]interface{}{
+		"size": 1,
+		"type": "IMAGE",
+	}
+	if albumID != "" {
+		reqBody["albumIds"] = []string{albumID}
+	}
+
+	bodyJSON, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	resp, err := c.doRequest("POST", serverURL, apiKey, "/search/random", strings.NewReader(string(bodyJSON)))
+	if err != nil {
+		return nil, fmt.Errorf("failed to search random: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		bodyBytes, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("server returned status %d: %s", resp.StatusCode, string(bodyBytes))
+	}
+
+	var assets []Asset
+	if err := json.NewDecoder(resp.Body).Decode(&assets); err != nil {
+		return nil, fmt.Errorf("failed to decode assets: %w", err)
+	}
+
+	if len(assets) == 0 {
+		return nil, fmt.Errorf("no assets found")
+	}
+
+	return &assets[0], nil
+}
+
+// DownloadAsset downloads the original file for an asset.
+func (c *Client) DownloadAsset(serverURL, apiKey, assetID string) ([]byte, error) {
+	url := strings.TrimRight(serverURL, "/") + "/api/assets/" + assetID + "/original"
+
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("x-api-key", apiKey)
+
+	// Use a longer timeout for downloads
+	downloadClient := &http.Client{
+		Timeout: 60 * time.Second,
+	}
+
+	resp, err := downloadClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to download asset: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		bodyBytes, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("server returned status %d: %s", resp.StatusCode, string(bodyBytes))
+	}
+
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read asset data: %w", err)
+	}
+
+	return data, nil
+}

--- a/webapp/src/api.ts
+++ b/webapp/src/api.ts
@@ -247,3 +247,26 @@ export const googleCalendarLogout = async () => {
   const response = await api.post('auth/google-calendar/logout');
   return response.data;
 };
+
+// Immich
+export const testImmichConnection = async (
+  serverUrl: string,
+  apiKey: string
+) => {
+  const response = await api.post('immich/test', {
+    server_url: serverUrl,
+    api_key: apiKey,
+  });
+  return response.data;
+};
+
+export const listImmichAlbums = async (
+  serverUrl: string,
+  apiKey: string
+) => {
+  const response = await api.post('immich/albums', {
+    server_url: serverUrl,
+    api_key: apiKey,
+  });
+  return response.data;
+};

--- a/webapp/src/components/Settings.vue
+++ b/webapp/src/components/Settings.vue
@@ -50,6 +50,7 @@
               <v-tab value="telegram">Telegram</v-tab>
               <v-tab value="url">URL Proxy</v-tab>
               <v-tab value="ai_generation">AI Generation</v-tab>
+              <v-tab value="immich_photos">Immich</v-tab>
             </v-tabs>
 
             <v-window v-model="activeDataSourceTab">
@@ -580,6 +581,128 @@
                     <v-btn color="primary" class="mt-4" @click="save"
                       >Save Token</v-btn
                     >
+                  </div>
+                </v-card-text>
+              </v-window-item>
+
+              <!-- Immich Photos -->
+              <v-window-item value="immich_photos">
+                <v-card-text>
+                  <div v-if="form.immich_connected">
+                    <v-alert
+                      type="success"
+                      variant="tonal"
+                      class="mb-4"
+                      density="compact"
+                      icon="mdi-check-circle"
+                    >
+                      Connected to Immich Server ({{ form.immich_url }})
+                    </v-alert>
+
+                    <v-text-field
+                      :model-value="getImageUrl('immich_photos')"
+                      label="Image Endpoint URL (for firmware config)"
+                      readonly
+                      variant="outlined"
+                      density="compact"
+                      append-inner-icon="mdi-content-copy"
+                      @click:append-inner="
+                        copyToClipboard(getImageUrl('immich_photos'))
+                      "
+                      class="mb-4"
+                    ></v-text-field>
+
+                    <v-text-field
+                      v-model="form.immich_url"
+                      label="Immich Server URL"
+                      variant="outlined"
+                      density="compact"
+                      class="mb-2"
+                    ></v-text-field>
+
+                    <v-text-field
+                      v-model="form.immich_api_key"
+                      label="API Key"
+                      type="password"
+                      variant="outlined"
+                      density="compact"
+                      class="mb-4"
+                    ></v-text-field>
+
+                    <v-row class="mt-2">
+                      <v-col cols="12" sm="8">
+                        <v-select
+                          v-model="form.immich_album_id"
+                          :items="immichAlbumOptions"
+                          item-title="name"
+                          item-value="id"
+                          label="Album"
+                          variant="outlined"
+                          density="compact"
+                          hint="Select an album to pick random photos from, or leave as 'All Photos'"
+                          persistent-hint
+                        ></v-select>
+                      </v-col>
+                      <v-col cols="12" sm="4">
+                        <v-btn block variant="outlined" @click="loadImmichAlbums"
+                          >Refresh Albums</v-btn
+                        >
+                      </v-col>
+                    </v-row>
+
+                    <div class="d-flex flex-wrap ga-2 mt-4">
+                      <v-btn color="primary" @click="saveImmichSettings"
+                        >Save Settings</v-btn
+                      >
+                      <v-btn
+                        color="error"
+                        variant="text"
+                        @click="disconnectImmich"
+                        >Disconnect</v-btn
+                      >
+                    </div>
+                  </div>
+
+                  <div v-else>
+                    <v-alert
+                      type="info"
+                      variant="tonal"
+                      class="mb-4"
+                      density="compact"
+                    >
+                      Connect to your Immich server to display random photos
+                      from your library or a specific album. No photos are
+                      imported — they are fetched directly from Immich on each
+                      request.
+                    </v-alert>
+
+                    <v-text-field
+                      v-model="form.immich_url"
+                      label="Immich Server URL"
+                      placeholder="http://192.168.1.100:2283"
+                      variant="outlined"
+                      class="mb-2"
+                    ></v-text-field>
+
+                    <v-text-field
+                      v-model="form.immich_api_key"
+                      label="API Key"
+                      type="password"
+                      variant="outlined"
+                      class="mb-2"
+                      hint="Generate an API key in Immich → User Settings → API Keys"
+                      persistent-hint
+                    ></v-text-field>
+
+                    <v-btn
+                      color="primary"
+                      class="mt-4"
+                      :disabled="!form.immich_url || !form.immich_api_key"
+                      :loading="immichTesting"
+                      @click="testImmich"
+                    >
+                      Test Connection & Save
+                    </v-btn>
                   </div>
                 </v-card-text>
               </v-window-item>
@@ -1359,6 +1482,8 @@ import {
   listCalendars,
   googleCalendarLogin,
   googleCalendarLogout,
+  testImmichConnection,
+  listImmichAlbums,
 } from '../api';
 import Gallery from './Gallery.vue';
 import ConfirmDialog from './ConfirmDialog.vue';
@@ -1382,6 +1507,7 @@ const sourceOptions = [
   { title: 'Telegram', value: 'telegram' },
   { title: 'URL Proxy', value: 'url_proxy' },
   { title: 'AI Generation', value: 'ai_generation' },
+  { title: 'Immich Photos', value: 'immich_photos' },
 ];
 const isBinding = ref(false);
 
@@ -1625,6 +1751,10 @@ watch(activeDataSourceTab, (val) => {
     loadURLSources();
   } else if (val === 'google') {
     loadCalendars();
+  } else if (val === 'immich_photos') {
+    if (form.immich_connected && form.immich_albums.length === 0) {
+      loadImmichAlbums();
+    }
   }
 });
 
@@ -1863,6 +1993,11 @@ const form = reactive({
   telegram_target_device_id: [] as number[],
   openai_api_key: '',
   google_api_key: '',
+  immich_url: '',
+  immich_api_key: '',
+  immich_album_id: '',
+  immich_connected: false,
+  immich_albums: [] as any[],
   device_host: '', // Keep for backward compatibility/display? Or remove. Remove from form, keep in store maybe?
 });
 
@@ -1913,6 +2048,10 @@ onMounted(async () => {
     synology_sid: store.settings.synology_sid || '',
     openai_api_key: store.settings.openai_api_key || '',
     google_api_key: store.settings.google_api_key || '',
+    immich_url: store.settings.immich_url || '',
+    immich_api_key: store.settings.immich_api_key || '',
+    immich_album_id: store.settings.immich_album_id || '',
+    immich_connected: !!(store.settings.immich_url && store.settings.immich_api_key),
   });
 
   // Load cached albums if available
@@ -1975,6 +2114,9 @@ const saveSettingsInternal = async () => {
     synology_album_id: String(form.synology_album_id),
     openai_api_key: form.openai_api_key,
     google_api_key: form.google_api_key,
+    immich_url: form.immich_url,
+    immich_api_key: form.immich_api_key,
+    immich_album_id: form.immich_album_id,
   });
 };
 
@@ -2287,5 +2429,82 @@ const getDeviceFromUA = (ua: string) => {
   if (ua.includes('Android')) return 'Android';
   if (ua.includes('Linux')) return 'Linux';
   return 'Other Device';
+};
+
+// Immich State
+const immichTesting = ref(false);
+
+const immichAlbumOptions = computed(() => {
+  return [{ id: '', name: 'All Photos' }, ...form.immich_albums.map((a: any) => ({ id: a.id, name: `${a.albumName} (${a.assetCount})` }))];
+});
+
+const testImmich = async () => {
+  if (!form.immich_url || !form.immich_api_key) {
+    showMessage('Server URL and API Key are required', true);
+    return;
+  }
+  immichTesting.value = true;
+  try {
+    await testImmichConnection(form.immich_url, form.immich_api_key);
+    // Connection successful - save settings
+    await saveSettingsInternal();
+    form.immich_connected = true;
+    showMessage('Connected to Immich server!');
+    // Try to load albums
+    await loadImmichAlbums();
+  } catch (e: any) {
+    showMessage(
+      'Connection failed: ' + (e.response?.data?.error || e.message),
+      true
+    );
+  } finally {
+    immichTesting.value = false;
+  }
+};
+
+const loadImmichAlbums = async () => {
+  if (!form.immich_url || !form.immich_api_key) {
+    showMessage('Server URL and API Key are required', true);
+    return;
+  }
+  try {
+    const albums = await listImmichAlbums(form.immich_url, form.immich_api_key);
+    form.immich_albums = albums;
+    showMessage('Albums loaded!');
+  } catch (e: any) {
+    showMessage(
+      'Failed to load albums: ' + (e.response?.data?.error || e.message),
+      true
+    );
+  }
+};
+
+const saveImmichSettings = async () => {
+  try {
+    await saveSettingsInternal();
+    showMessage('Immich settings saved!');
+  } catch (e: any) {
+    showMessage('Failed to save: ' + (e.message || 'Unknown error'), true);
+  }
+};
+
+const disconnectImmich = async () => {
+  if (
+    !(await confirmDialog.value.open(
+      'Are you sure you want to disconnect Immich?'
+    ))
+  )
+    return;
+  form.immich_url = '';
+  form.immich_api_key = '';
+  form.immich_album_id = '';
+  form.immich_albums = [];
+  form.immich_connected = false;
+  try {
+    await saveSettingsInternal();
+    showMessage('Disconnected from Immich.');
+  } catch (e: any) {
+    showMessage('Error disconnecting: ' + e, true);
+  }
 };
 </script>


### PR DESCRIPTION
One of the biggest reasons I found your projects is I was planning on making a server myself to integrate with Immich. After being reinspired by [this issue](https://github.com/aitjcize/esp32-photoframe-server/issues/11), I figured that rather than reinvent the wheel, I'll just combine my Immich logic into your server.

Tested as working with my own Immich server running v2.5.6

Edit: Since Immich is already a self-hosted photo server, we're selecting a file at random from a chosen album, or the whole library.

<img width="1177" height="621" alt="image" src="https://github.com/user-attachments/assets/2bbf5fe0-4a2c-4b55-9697-00ddafb5d5e0" />
