### PR TITLE
fix: Synology Personal album thumbnails returning 404

### DIFF
--- a/backend/internal/model/model.go
+++ b/backend/internal/model/model.go
@@ -32,6 +32,7 @@ type Image struct {
 	SynologyPhotoID int            `json:"synology_id"`
 	SynologySpace   string         `json:"synology_space"` // "personal" or "shared"
 	ThumbnailKey    string         `json:"thumbnail_key"`  // Cache key for Synology
+	SynologyUnitID  int            `json:"synology_unit_id"` // unit_id for Personal album thumbnails
 	CreatedAt       time.Time      `json:"created_at"`
 	DeletedAt       gorm.DeletedAt `gorm:"index" json:"-"`
 }

--- a/backend/internal/service/synology.go
+++ b/backend/internal/service/synology.go
@@ -137,8 +137,14 @@ func (s *SynologyService) GetPhoto(id int, cacheKeyStr, size string) ([]byte, er
 		}
 	}
 
-	// Use stored ThumbnailKey (cache_key), SynologySpace, albumID, and SynoToken
-	return s.client.GetPhoto(id, img.ThumbnailKey, size, img.SynologySpace, albumID, s.client.SynoToken)
+	// For Personal albums, use unit_id instead of photo id for thumbnail requests
+	photoID := id
+	if img.SynologySpace == "personal" && img.SynologyUnitID != 0 {
+		photoID = img.SynologyUnitID
+		albumID = 0 // Personal thumbnails don't need album_id
+	}
+
+	return s.client.GetPhoto(photoID, img.ThumbnailKey, size, img.SynologySpace, albumID, s.client.SynoToken)
 }
 
 func (s *SynologyService) ListAlbums() ([]synology.Album, error) {
@@ -257,22 +263,27 @@ func (s *SynologyService) ImportPhotos() error {
 			}
 
 			// Create
+			// Use cache_key if available (needed for Personal album thumbnails), else fall back to status string
+			thumbKey := p.Additional.Thumbnail.CacheKey
+			if thumbKey == "" {
+				thumbKey = p.Additional.Thumbnail.XL
+			}
+			if thumbKey == "" {
+				thumbKey = p.Additional.Thumbnail.M
+			}
+
 			img := model.Image{
 				SynologyPhotoID: p.ID,
 				SynologySpace:   space,
 				Source:          model.SourceSynologyPhotos,
 				FilePath:        p.Filename,
-				ThumbnailKey:    p.Additional.Thumbnail.M,
+				ThumbnailKey:    thumbKey,
+				SynologyUnitID:  p.Additional.Thumbnail.UnitID,
 				Width:           pw,
 				Height:          ph,
 				Orientation:     orientation,
 				CreatedAt:       time.Now(),
 				Status:          "pending",
-			}
-
-			// Use XL cache key if available
-			if p.Additional.Thumbnail.XL != "" {
-				img.ThumbnailKey = p.Additional.Thumbnail.XL
 			}
 
 			if err := s.db.Create(&img).Error; err != nil {

--- a/backend/pkg/synology/client.go
+++ b/backend/pkg/synology/client.go
@@ -178,7 +178,13 @@ func (c *Client) ListAlbums(offset, limit int) ([]Album, error) {
 func (c *Client) ListPhotos(offset, limit int, albumID int, space string) ([]Item, error) {
 	endpoint := fmt.Sprintf("%s/webapi/entry.cgi", c.BaseURL)
 	params := url.Values{}
-	params.Set("api", "SYNO.Foto.Browse.Item")
+
+	if space == "shared" {
+		params.Set("api", "SYNO.FotoTeam.Browse.Item")
+	} else {
+		params.Set("api", "SYNO.Foto.Browse.Item")
+	}
+
 	params.Set("version", "1")
 	params.Set("method", "list")
 	params.Set("type", "photo")
@@ -254,7 +260,7 @@ func (c *Client) GetPhoto(id int, cacheKey string, size string, space string, al
 		"type=%22unit%22",
 		fmt.Sprintf("size=%s", url.QueryEscape(fmt.Sprintf("\"%s\"", sz))),
 	}
-	if albumID != 0 {
+	if albumID != 0 && space == "shared" {
 		parts = append(parts, fmt.Sprintf("album_id=%d", albumID))
 	}
 	parts = append(parts,

--- a/backend/pkg/synology/types.go
+++ b/backend/pkg/synology/types.go
@@ -21,9 +21,12 @@ type Item struct {
 	Type        string `json:"type"` // "photo" or "video"
 	Additional  struct {
 		Thumbnail struct {
-			M  string `json:"m"` // Cache key or similar
-			XL string `json:"xl"`
-			S  string `json:"s"`
+			M        string `json:"m"`
+			XL       string `json:"xl"`
+			S        string `json:"s"`
+			Sm       string `json:"sm"`
+			CacheKey string `json:"cache_key"`
+			UnitID   int    `json:"unit_id"`
 		} `json:"thumbnail"`
 		Resolution struct {
 			Width  int `json:"width"`


### PR DESCRIPTION
## Problem

When using a **Personal space album** in Synology Photos, thumbnails fail to load with HTTP 404 errors.

Root causes:
1. `album_id` was being sent with thumbnail requests for Personal space — Synology rejects this with 404
2. `unit_id` and `cache_key` fields from the Synology API response were not mapped in the Go struct or stored in the DB
3. Personal album thumbnail requests need to use `unit_id` (not `photo id`) as the ID parameter
4. Listing photos in Shared space should use `SYNO.FotoTeam.Browse.Item` API

## Changes

- **`types.go`**: Added `CacheKey` and `UnitID` fields to `Thumbnail` struct
- **`model.go`**: Added `SynologyUnitID` field to `Image` model
- **`synology.go`**: Store `cache_key` and `unit_id` during sync; use `unit_id` for Personal album thumbnail requests
- **`client.go`**: Only send `album_id` in thumbnail requests for Shared space; use correct API for Shared space listing

## Testing

Tested with Synology Photos Personal space album — thumbnails now load correctly.