### PR TITLE
Update Docker image reference in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ docker run -d \
   -p 9607:9607 \
   -v /path/to/data:/data \
   --name photoframe-server \
-  ghcr.io/aitjcize/esp32-photoframe-server:latest
+  aitjcize/esp32-photoframe-server:latest
 ```
 
 ## Configuration


### PR DESCRIPTION
The image reference does not seem to be right or the registry is made private.

The image does however, seem to be publicly available on docker hub. This documentation change fixes that

fixes #19 