### PR TITLE
HA ingress auth support with trusted ingress checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,22 @@ The easiest way to run the server is as a Home Assistant add-on.
    - Enable **Start on boot** if desired
    - Access via the sidebar or `http://homeassistant.local:9607`
 
+#### Ingress Authentication
+
+When accessing the UI through the Home Assistant sidebar (Ingress), this add-on now skips the app login screen.
+
+- Home Assistant authentication is trusted for ingress requests.
+- JWT login is still required for non-ingress/direct access (for example `http://homeassistant.local:9607`).
+- Ingress bypass is only enabled when both checks pass:
+   - Request includes `X-Ingress-Path`
+   - TCP socket source IP (`RemoteAddr`) matches the trusted ingress proxy IP (default: `172.30.32.2`)
+
+If your Home Assistant environment uses a different ingress proxy IP, set this environment variable for the container:
+
+```bash
+HA_INGRESS_PROXY_IP=<your-supervisor-ingress-ip>
+```
+
 #### Data Migration
 
 If upgrading from a previous version that used `/config/esp32-photoframe-server/`:

--- a/backend/internal/handler/auth.go
+++ b/backend/internal/handler/auth.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"net/http"
 
+	"github.com/aitjcize/esp32-photoframe-server/backend/internal/security"
 	"github.com/aitjcize/esp32-photoframe-server/backend/internal/service"
 	"github.com/labstack/echo/v4"
 )
@@ -70,9 +71,11 @@ func (h *AuthHandler) GetStatus(c echo.Context) error {
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "database error"})
 	}
+	isIngress := security.IsTrustedIngressRequest(c)
 
 	return c.JSON(http.StatusOK, map[string]bool{
 		"initialized": count > 0,
+		"ingress":     isIngress,
 	})
 }
 

--- a/backend/internal/middleware/auth.go
+++ b/backend/internal/middleware/auth.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/aitjcize/esp32-photoframe-server/backend/internal/security"
 	"github.com/aitjcize/esp32-photoframe-server/backend/internal/service"
 	"github.com/labstack/echo/v4"
 )
@@ -11,6 +12,17 @@ import (
 func JWTMiddleware(authService *service.AuthService) echo.MiddlewareFunc {
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error {
+			if security.IsTrustedIngressRequest(c) {
+				user, err := authService.GetPrimaryUser()
+				if err != nil {
+					return c.JSON(http.StatusUnauthorized, map[string]string{"error": "no user account configured"})
+				}
+
+				c.Set("user_id", user.ID)
+				c.Set("username", user.Username)
+				return next(c)
+			}
+
 			// Extract token
 			tokenString := extractToken(c)
 			if tokenString == "" {

--- a/backend/internal/security/ingress.go
+++ b/backend/internal/security/ingress.go
@@ -1,0 +1,34 @@
+package security
+
+import (
+	"net"
+	"os"
+
+	"github.com/labstack/echo/v4"
+)
+
+// IsTrustedIngressRequest returns true when a request is coming through
+// Home Assistant ingress from the trusted Supervisor ingress proxy.
+func IsTrustedIngressRequest(c echo.Context) bool {
+	if c.Request().Header.Get("X-Ingress-Path") == "" {
+		return false
+	}
+
+	trustedProxyIP := os.Getenv("HA_INGRESS_PROXY_IP")
+	if trustedProxyIP == "" {
+		trustedProxyIP = "172.30.32.2"
+	}
+
+	trustedIP := net.ParseIP(trustedProxyIP)
+	if trustedIP == nil {
+		return false
+	}
+
+	remoteHost, _, err := net.SplitHostPort(c.Request().RemoteAddr)
+	if err != nil {
+		remoteHost = c.Request().RemoteAddr
+	}
+
+	remoteIP := net.ParseIP(remoteHost)
+	return remoteIP != nil && remoteIP.Equal(trustedIP)
+}

--- a/backend/internal/service/auth.go
+++ b/backend/internal/service/auth.go
@@ -40,6 +40,15 @@ func (s *AuthService) UserCount() (int64, error) {
 	return count, err
 }
 
+// GetPrimaryUser returns the oldest user account, used for trusted ingress sessions.
+func (s *AuthService) GetPrimaryUser() (*model.User, error) {
+	var user model.User
+	if err := s.db.Order("id ASC").First(&user).Error; err != nil {
+		return nil, err
+	}
+	return &user, nil
+}
+
 func (s *AuthService) Register(username, password string) error {
 	// Check if user exists
 	var count int64

--- a/webapp/src/stores/auth.ts
+++ b/webapp/src/stores/auth.ts
@@ -5,11 +5,12 @@ import { api } from '../api';
 export const useAuthStore = defineStore('auth', () => {
   const token = ref<string | null>(localStorage.getItem('token'));
   const isInitialized = ref<boolean>(false);
+  const isIngress = ref<boolean>(false);
   const loading = ref<boolean>(false);
   const error = ref<string | null>(null);
   const tokens = ref<any[]>([]);
 
-  const isLoggedIn = computed(() => !!token.value);
+  const isLoggedIn = computed(() => !!token.value || isIngress.value);
 
   function setToken(newToken: string) {
     token.value = newToken;
@@ -26,8 +27,10 @@ export const useAuthStore = defineStore('auth', () => {
       loading.value = true;
       const res = await api.get('auth/status');
       isInitialized.value = res.data.initialized;
+      isIngress.value = !!res.data.ingress;
     } catch (err: any) {
       console.error('Failed to check status', err);
+      isIngress.value = false;
     } finally {
       loading.value = false;
     }
@@ -65,6 +68,7 @@ export const useAuthStore = defineStore('auth', () => {
     token,
     tokens,
     isInitialized,
+    isIngress,
     isLoggedIn,
     loading,
     error,


### PR DESCRIPTION
## Maintainer Note / Disclosure
I am a C++ developer and have no prior professional experience with Go.

I used this project to try out AI tooling from work for a hobby project, and this branch was mostly vibecoded. I reviewed the diff myself, but I also used AI to write substantial parts of the implementation and this PR text.

I Hope this is fine, given that Claude is also used in the original project context?

## Net Changes In This Diff
1. Adds Home Assistant ingress-aware auth handling for trusted ingress requests.
2. Centralizes ingress trust checks in shared ingress security logic.
3. Keeps non-ingress authentication flow unchanged.
4. Applies ingress trust checks where auth decisions are made for ingress requests.
5. On first setup an account still needs to be created, but on second opening ingress will use this account to login paswordless


## Testing
- I tested ingress auth locally and it works in my setup.
