### PR TITLE
Enforce referential integrity with ON DELETE foreign keys

### DIFF
--- a/backend/db/migrations/000032_foreign_key_cascades.down.sql
+++ b/backend/db/migrations/000032_foreign_key_cascades.down.sql
@@ -1,0 +1,55 @@
+-- Revert to the original constraint-free junction/child tables. Data-preserving:
+-- rebuild each table without FOREIGN KEY clauses and copy every row back.
+
+CREATE TABLE image_album_memberships_new (
+    image_id INTEGER NOT NULL,
+    album_id INTEGER NOT NULL,
+    PRIMARY KEY (image_id, album_id)
+);
+INSERT INTO image_album_memberships_new SELECT image_id, album_id FROM image_album_memberships;
+DROP TABLE image_album_memberships;
+ALTER TABLE image_album_memberships_new RENAME TO image_album_memberships;
+CREATE INDEX idx_iam_album ON image_album_memberships(album_id);
+
+CREATE TABLE device_album_mappings_new (
+    device_id INTEGER NOT NULL,
+    album_id INTEGER NOT NULL,
+    PRIMARY KEY (device_id, album_id)
+);
+INSERT INTO device_album_mappings_new SELECT device_id, album_id FROM device_album_mappings;
+DROP TABLE device_album_mappings;
+ALTER TABLE device_album_mappings_new RENAME TO device_album_mappings;
+CREATE INDEX idx_dam_album ON device_album_mappings(album_id);
+
+CREATE TABLE device_url_mappings_new (
+    device_id INTEGER,
+    url_source_id INTEGER,
+    PRIMARY KEY (device_id, url_source_id)
+);
+INSERT INTO device_url_mappings_new SELECT device_id, url_source_id FROM device_url_mappings;
+DROP TABLE device_url_mappings;
+ALTER TABLE device_url_mappings_new RENAME TO device_url_mappings;
+
+CREATE TABLE generative_states_new (
+    device_id INTEGER NOT NULL,
+    source TEXT NOT NULL,
+    state BLOB,
+    updated_at DATETIME,
+    PRIMARY KEY (device_id, source)
+);
+INSERT INTO generative_states_new SELECT device_id, source, state, updated_at FROM generative_states;
+DROP TABLE generative_states;
+ALTER TABLE generative_states_new RENAME TO generative_states;
+
+CREATE TABLE device_histories_new (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    device_id INTEGER,
+    image_id INTEGER,
+    served_at DATETIME
+);
+INSERT INTO device_histories_new (id, device_id, image_id, served_at)
+    SELECT id, device_id, image_id, served_at FROM device_histories;
+DROP TABLE device_histories;
+ALTER TABLE device_histories_new RENAME TO device_histories;
+CREATE INDEX idx_device_histories_device_id ON device_histories(device_id);
+CREATE INDEX idx_device_histories_device_served ON device_histories(device_id, served_at DESC);

--- a/backend/db/migrations/000032_foreign_key_cascades.up.sql
+++ b/backend/db/migrations/000032_foreign_key_cascades.up.sql
@@ -1,0 +1,101 @@
+-- Add real foreign keys with ON DELETE actions to the junction/child tables so
+-- referential integrity is enforced by the DB instead of by hand-written cleanup
+-- scattered across the Go handlers (DeleteDevice, DeletePhoto, clearSourcePhotos,
+-- SetSyncTopics, ...). Paired with _foreign_keys=on in the connection DSN.
+--
+-- SQLite can't ALTER TABLE ADD CONSTRAINT, so each table is rebuilt (create new,
+-- copy, drop, rename). This runs with foreign_keys=ON (enforcement is enabled in
+-- the DSN), so the copy must already satisfy the constraints: the INSERT..SELECT
+-- for each table copies only rows whose parents still exist, which purges any
+-- pre-existing orphans in the same step. All five are leaf tables (nothing
+-- references them), so dropping/renaming can't violate an inbound FK.
+--
+-- ON DELETE actions:
+--   * CASCADE everywhere a child row is meaningless without its parent (a
+--     membership without its image/album, a mapping without its device/album/
+--     url-source, a generative state without its device, a history row without
+--     its device).
+--   * SET NULL for device_histories.image_id — the "what was served when" log is
+--     worth keeping after the photo is deleted; just drop the dangling reference.
+
+-- image_album_memberships: image_id, album_id both CASCADE
+CREATE TABLE image_album_memberships_new (
+    image_id INTEGER NOT NULL,
+    album_id INTEGER NOT NULL,
+    PRIMARY KEY (image_id, album_id),
+    FOREIGN KEY (image_id) REFERENCES images(id) ON DELETE CASCADE,
+    FOREIGN KEY (album_id) REFERENCES albums(id) ON DELETE CASCADE
+);
+INSERT INTO image_album_memberships_new (image_id, album_id)
+    SELECT image_id, album_id FROM image_album_memberships
+    WHERE image_id IN (SELECT id FROM images)
+      AND album_id IN (SELECT id FROM albums);
+DROP TABLE image_album_memberships;
+ALTER TABLE image_album_memberships_new RENAME TO image_album_memberships;
+CREATE INDEX idx_iam_album ON image_album_memberships(album_id);
+
+-- device_album_mappings: device_id, album_id both CASCADE
+CREATE TABLE device_album_mappings_new (
+    device_id INTEGER NOT NULL,
+    album_id INTEGER NOT NULL,
+    PRIMARY KEY (device_id, album_id),
+    FOREIGN KEY (device_id) REFERENCES devices(id) ON DELETE CASCADE,
+    FOREIGN KEY (album_id) REFERENCES albums(id) ON DELETE CASCADE
+);
+INSERT INTO device_album_mappings_new (device_id, album_id)
+    SELECT device_id, album_id FROM device_album_mappings
+    WHERE device_id IN (SELECT id FROM devices)
+      AND album_id IN (SELECT id FROM albums);
+DROP TABLE device_album_mappings;
+ALTER TABLE device_album_mappings_new RENAME TO device_album_mappings;
+CREATE INDEX idx_dam_album ON device_album_mappings(album_id);
+
+-- device_url_mappings: device_id, url_source_id both CASCADE
+CREATE TABLE device_url_mappings_new (
+    device_id INTEGER,
+    url_source_id INTEGER,
+    PRIMARY KEY (device_id, url_source_id),
+    FOREIGN KEY (device_id) REFERENCES devices(id) ON DELETE CASCADE,
+    FOREIGN KEY (url_source_id) REFERENCES url_sources(id) ON DELETE CASCADE
+);
+INSERT INTO device_url_mappings_new (device_id, url_source_id)
+    SELECT device_id, url_source_id FROM device_url_mappings
+    WHERE device_id IN (SELECT id FROM devices)
+      AND url_source_id IN (SELECT id FROM url_sources);
+DROP TABLE device_url_mappings;
+ALTER TABLE device_url_mappings_new RENAME TO device_url_mappings;
+
+-- generative_states: device_id CASCADE
+CREATE TABLE generative_states_new (
+    device_id INTEGER NOT NULL,
+    source TEXT NOT NULL,
+    state BLOB,
+    updated_at DATETIME,
+    PRIMARY KEY (device_id, source),
+    FOREIGN KEY (device_id) REFERENCES devices(id) ON DELETE CASCADE
+);
+INSERT INTO generative_states_new (device_id, source, state, updated_at)
+    SELECT device_id, source, state, updated_at FROM generative_states
+    WHERE device_id IN (SELECT id FROM devices);
+DROP TABLE generative_states;
+ALTER TABLE generative_states_new RENAME TO generative_states;
+
+-- device_histories: device_id CASCADE, image_id SET NULL
+CREATE TABLE device_histories_new (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    device_id INTEGER,
+    image_id INTEGER,
+    served_at DATETIME,
+    FOREIGN KEY (device_id) REFERENCES devices(id) ON DELETE CASCADE,
+    FOREIGN KEY (image_id) REFERENCES images(id) ON DELETE SET NULL
+);
+INSERT INTO device_histories_new (id, device_id, image_id, served_at)
+    SELECT id, device_id,
+           CASE WHEN image_id IN (SELECT id FROM images) THEN image_id ELSE NULL END,
+           served_at
+    FROM device_histories
+    WHERE device_id IS NULL OR device_id IN (SELECT id FROM devices);
+DROP TABLE device_histories;
+ALTER TABLE device_histories_new RENAME TO device_histories;
+CREATE INDEX idx_device_histories_device_id ON device_histories(device_id);
+CREATE INDEX idx_device_histories_device_served ON device_histories(device_id, served_at DESC);

--- a/backend/internal/db/db.go
+++ b/backend/internal/db/db.go
@@ -20,7 +20,11 @@ func Init(dbPath string) (*gorm.DB, error) {
 	// 30s is the conventional SQLite "be patient" budget — long enough to
 	// outlast a multi-thousand-photo Synology / Immich sync that's writing
 	// one row at a time, short enough that a real deadlock still surfaces.
-	dsn := dbPath + "?_journal_mode=WAL&_busy_timeout=30000&_synchronous=NORMAL"
+	// _foreign_keys=on enforces the ON DELETE CASCADE / SET NULL constraints on
+	// the junction/child tables (see migration 000032). SQLite defaults this OFF
+	// per-connection; with SetMaxOpenConns(1) below it's set once on the single
+	// connection and every query inherits it.
+	dsn := dbPath + "?_journal_mode=WAL&_busy_timeout=30000&_synchronous=NORMAL&_foreign_keys=on"
 	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
 	if err != nil {
 		return nil, err

--- a/backend/internal/db/db_test.go
+++ b/backend/internal/db/db_test.go
@@ -8,7 +8,36 @@ import (
 	"github.com/golang-migrate/migrate/v4"
 	"github.com/golang-migrate/migrate/v4/database/sqlite3"
 	_ "github.com/golang-migrate/migrate/v4/source/file"
+	"gorm.io/gorm"
 )
+
+// migratedDB opens a fresh SQLite database through the production Init path and
+// applies the full migration chain, returning the connection. This is the real
+// startup path (Init's DSN enables _foreign_keys=on).
+func migratedDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "migrate.db")
+	gdb, err := Init(dbPath)
+	if err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	sqlDB, err := gdb.DB()
+	if err != nil {
+		t.Fatalf("db handle: %v", err)
+	}
+	driver, err := sqlite3.WithInstance(sqlDB, &sqlite3.Config{})
+	if err != nil {
+		t.Fatalf("sqlite3 driver: %v", err)
+	}
+	m, err := migrate.NewWithDatabaseInstance(migrationsURL(t), "sqlite3", driver)
+	if err != nil {
+		t.Fatalf("migrate init: %v", err)
+	}
+	if err := m.Up(); err != nil && err != migrate.ErrNoChange {
+		t.Fatalf("migrate up failed: %v", err)
+	}
+	return gdb
+}
 
 // migrationsURL resolves the real db/migrations directory relative to this
 // test file, independent of the test's working directory.
@@ -68,5 +97,82 @@ func TestMigrationsApplyCleanly(t *testing.T) {
 		if name == "asset_count" {
 			t.Fatal("albums.asset_count should have been dropped by migration 000027")
 		}
+	}
+}
+
+// TestForeignKeyCascades verifies the ON DELETE CASCADE / SET NULL constraints
+// added in migration 000032 actually fire — i.e. that Init enables enforcement
+// (_foreign_keys=on) and the rebuilt junction/child tables carry the FKs. This
+// is the behavior the removed hand-written cleanup now relies on.
+func TestForeignKeyCascades(t *testing.T) {
+	gdb := migratedDB(t)
+
+	// Enforcement must be on, or every cascade below is a silent no-op.
+	var fk int
+	if err := gdb.Raw("PRAGMA foreign_keys").Scan(&fk).Error; err != nil {
+		t.Fatalf("read pragma: %v", err)
+	}
+	if fk != 1 {
+		t.Fatalf("foreign_keys pragma = %d, want 1 (enforcement off — cascades won't fire)", fk)
+	}
+
+	exec := func(q string) {
+		t.Helper()
+		if err := gdb.Exec(q).Error; err != nil {
+			t.Fatalf("exec %q: %v", q, err)
+		}
+	}
+	count := func(q string) int {
+		t.Helper()
+		var n int
+		if err := gdb.Raw(q).Scan(&n).Error; err != nil {
+			t.Fatalf("count %q: %v", q, err)
+		}
+		return n
+	}
+
+	// Seed one parent of each kind plus a child in every constrained table.
+	exec("INSERT INTO devices(id) VALUES (1)")
+	exec("INSERT INTO images(id, source, external_id) VALUES (10, 'immich', 'x')")
+	exec("INSERT INTO albums(id, source, external_id, name) VALUES (100, 'immich', 'e', 'n')")
+	exec("INSERT INTO url_sources(id, url) VALUES (500, 'http://u')")
+	exec("INSERT INTO image_album_memberships(image_id, album_id) VALUES (10, 100)")
+	exec("INSERT INTO device_album_mappings(device_id, album_id) VALUES (1, 100)")
+	exec("INSERT INTO device_url_mappings(device_id, url_source_id) VALUES (1, 500)")
+	exec("INSERT INTO generative_states(device_id, source) VALUES (1, 'fractal')")
+	exec("INSERT INTO device_histories(device_id, image_id, served_at) VALUES (1, 10, '2026-01-01')")
+
+	// Deleting the image cascades its membership and NULLs (not deletes) the
+	// history reference.
+	exec("DELETE FROM images WHERE id = 10")
+	if got := count("SELECT COUNT(*) FROM image_album_memberships"); got != 0 {
+		t.Errorf("membership survived image delete: got %d, want 0", got)
+	}
+	if got := count("SELECT COUNT(*) FROM device_histories WHERE image_id IS NULL"); got != 1 {
+		t.Errorf("history image_id not set null: got %d rows null, want 1", got)
+	}
+	if got := count("SELECT COUNT(*) FROM device_histories"); got != 1 {
+		t.Errorf("history row wrongly deleted on image delete: got %d, want 1", got)
+	}
+
+	// Deleting the album cascades the device_album_mapping.
+	exec("DELETE FROM albums WHERE id = 100")
+	if got := count("SELECT COUNT(*) FROM device_album_mappings"); got != 0 {
+		t.Errorf("device_album_mapping survived album delete: got %d, want 0", got)
+	}
+
+	// Deleting the url source cascades the device_url_mapping.
+	exec("DELETE FROM url_sources WHERE id = 500")
+	if got := count("SELECT COUNT(*) FROM device_url_mappings"); got != 0 {
+		t.Errorf("device_url_mapping survived url_source delete: got %d, want 0", got)
+	}
+
+	// Deleting the device cascades its remaining children.
+	exec("DELETE FROM devices WHERE id = 1")
+	if got := count("SELECT COUNT(*) FROM generative_states"); got != 0 {
+		t.Errorf("generative_state survived device delete: got %d, want 0", got)
+	}
+	if got := count("SELECT COUNT(*) FROM device_histories"); got != 0 {
+		t.Errorf("device_history survived device delete: got %d, want 0", got)
 	}
 }

--- a/backend/internal/handler/gallery.go
+++ b/backend/internal/handler/gallery.go
@@ -375,9 +375,8 @@ func (h *GalleryHandler) DeletePhoto(c echo.Context) error {
 	if err := h.db.Unscoped().Delete(&item).Error; err != nil {
 		return respondError(c, http.StatusInternalServerError, "failed to delete from db")
 	}
-
-	// Drop album memberships for this image (consistent with the bulk delete).
-	h.db.Where("image_id = ?", item.ID).Delete(&model.ImageAlbumMembership{})
+	// Album memberships drop via ON DELETE CASCADE (this is an Unscoped hard
+	// delete, so the cascade fires).
 
 	// For local sources (gallery / google), drop the file and thumbnail.
 	// Synology / Immich keep the original on the source, so nothing on disk.
@@ -419,15 +418,7 @@ func (h *GalleryHandler) DeletePhotos(c echo.Context) error {
 		return respondError(c, http.StatusInternalServerError, "failed to delete from db")
 	}
 
-	// Drop album memberships for the deleted images so album counts reflect
-	// the removal (otherwise orphaned memberships linger).
-	if len(items) > 0 {
-		ids := make([]uint, len(items))
-		for i, it := range items {
-			ids[i] = it.ID
-		}
-		h.db.Where("image_id IN ?", ids).Delete(&model.ImageAlbumMembership{})
-	}
+	// Album memberships drop via ON DELETE CASCADE (Unscoped hard delete above).
 
 	// Disable sync for this source's albums so an auto-sync doesn't immediately
 	// re-import what was just deleted (no-op for sources without albums).
@@ -534,9 +525,7 @@ func (h *GalleryHandler) ListURLSources(c echo.Context) error {
 
 func (h *GalleryHandler) DeleteURLSource(c echo.Context) error {
 	id := c.Param("id")
-	// Delete mappings
-	h.db.Where("url_source_id = ?", id).Delete(&model.DeviceURLMapping{})
-	// Delete source
+	// device_url_mappings for this source drop via ON DELETE CASCADE.
 	if err := h.db.Delete(&model.URLSource{}, id).Error; err != nil {
 		return respondError(c, http.StatusInternalServerError, "failed to delete url source")
 	}

--- a/backend/internal/service/device.go
+++ b/backend/internal/service/device.go
@@ -257,33 +257,16 @@ func (s *DeviceService) RefreshDeviceFromHardware(id uint) (*model.Device, error
 }
 
 func (s *DeviceService) DeleteDevice(id uint) error {
-	// SQLite has no FK cascades enabled, so remove the device's child rows
-	// explicitly (in one transaction) to avoid orphans that a reused device id
-	// could later inherit.
+	// device_histories, device_album_mappings, device_url_mappings and
+	// generative_states are removed automatically via ON DELETE CASCADE
+	// (migration 000032, enforced by _foreign_keys=on) — Device has no
+	// soft-delete, so this is a real DELETE and the cascade fires. Only api_keys
+	// needs explicit handling: its device_id has no FK and tokens are unbound,
+	// not deleted, so a token survives the device it pointed at.
 	return s.db.Transaction(func(tx *gorm.DB) error {
-		// Child tables to clear (HasTable-guarded below, since not every model
-		// has a migration-created table in all DBs).
-		children := []interface{}{
-			&model.DeviceHistory{},
-			&model.DeviceAlbumMapping{},
-			&model.DeviceURLMapping{},
-			&model.GenerativeState{},
-		}
-		for _, m := range children {
-			// Some of these models have no migration-created table; skip those.
-			if !tx.Migrator().HasTable(m) {
-				continue
-			}
-			if err := tx.Where("device_id = ?", id).Delete(m).Error; err != nil {
-				return err
-			}
-		}
-		// Unbind (don't delete) any API tokens pointing at this device.
-		if tx.Migrator().HasTable(&model.APIKey{}) {
-			if err := tx.Model(&model.APIKey{}).
-				Where("device_id = ?", id).Update("device_id", nil).Error; err != nil {
-				return err
-			}
+		if err := tx.Model(&model.APIKey{}).
+			Where("device_id = ?", id).Update("device_id", nil).Error; err != nil {
+			return err
 		}
 		return tx.Delete(&model.Device{}, id).Error
 	})

--- a/backend/internal/service/photosync_common.go
+++ b/backend/internal/service/photosync_common.go
@@ -15,17 +15,10 @@ import (
 	"github.com/aitjcize/esp32-photoframe-server/backend/internal/model"
 )
 
-// clearSourcePhotos drops album memberships for the source's albums and then
-// hard-deletes all of the source's image rows.
+// clearSourcePhotos hard-deletes all of the source's image rows. Their album
+// memberships drop via ON DELETE CASCADE (this is an Unscoped hard delete, so
+// the cascade fires).
 func clearSourcePhotos(db *gorm.DB, source string) error {
-	var albumIDs []uint
-	db.Model(&model.Album{}).Where("source = ?", source).Pluck("id", &albumIDs)
-	if len(albumIDs) > 0 {
-		if err := db.Where("album_id IN ?", albumIDs).
-			Delete(&model.ImageAlbumMembership{}).Error; err != nil {
-			log.Printf("[%s] clear memberships for albums %v: %v", source, albumIDs, err)
-		}
-	}
 	if err := db.Unscoped().Where("source = ?", source).
 		Delete(&model.Image{}).Error; err != nil {
 		return err

--- a/backend/internal/service/topic_source.go
+++ b/backend/internal/service/topic_source.go
@@ -124,9 +124,9 @@ func (t *topicSource) SetSyncTopics(topics []string) error {
 			return e
 		}
 		for _, a := range stale {
-			if e := tx.Where("album_id = ?", a.ID).Delete(&model.ImageAlbumMembership{}).Error; e != nil {
-				return e
-			}
+			// Album has no soft-delete, so this is a real DELETE and the album's
+			// image_album_memberships drop via ON DELETE CASCADE; the now-orphaned
+			// images are swept by gcOrphanImagesForSource below.
 			if e := tx.Delete(&model.Album{}, a.ID).Error; e != nil {
 				return e
 			}


### PR DESCRIPTION
## Why

The junction/child tables had **no foreign keys**, and the SQLite DSN never enabled enforcement. Referential integrity was maintained entirely by hand-written cleanup scattered across the handlers — `DeleteDevice` even documented the gap: *"SQLite has no FK cascades enabled, so remove the device's child rows explicitly."* Miss one path and you get orphans; we found a real one (a `device_histories` row pointing at a deleted image).

This is the follow-up discussed after the v1.9.1 sync-corruption fix.

## What

**Migration `000032`** rebuilds the five constrained tables (SQLite can't `ALTER TABLE ADD CONSTRAINT`) with foreign keys:

| Table | FK → action |
|-------|-------------|
| `image_album_memberships` | image_id → **CASCADE**, album_id → **CASCADE** |
| `device_album_mappings` | device_id → **CASCADE**, album_id → **CASCADE** |
| `device_url_mappings` | device_id → **CASCADE**, url_source_id → **CASCADE** |
| `generative_states` | device_id → **CASCADE** |
| `device_histories` | device_id → **CASCADE**, image_id → **SET NULL** |

`device_histories.image_id` is **SET NULL** (not CASCADE) so the "what was served when" log survives a photo deletion. Pre-existing orphans are purged inside the same rebuild (`INSERT..SELECT` copies only rows whose parents exist).

The DSN adds `_foreign_keys=on` — reliable now that the pool is a single connection (`SetMaxOpenConns(1)` from v1.9.1).

**Code cleanup**: the now-redundant manual cleanup is removed — `DeleteDevice` collapses to the `api_keys` unbind + device delete; membership/mapping deletes drop from `DeletePhoto`/`DeletePhotos`/`clearSourcePhotos`/`SetSyncTopics`/`DeleteURLSource`. Re-bind and retention-prune deletes are kept (they aren't parent-delete cascades).

## Correctness notes

- Only `Image` has a soft-delete (`gorm.DeletedAt`); all its delete paths use `Unscoped()` (a real `DELETE`), so cascades fire. `Device`/`Album`/`URLSource` have no soft-delete.
- `api_keys` is deliberately **not** rebuilt (auth table); `DeleteDevice` keeps its existing token-unbind.

## Testing

- New `TestForeignKeyCascades` runs through the real `Init`+migrate path, asserts `PRAGMA foreign_keys=1`, and verifies every cascade + the SET NULL.
- Migration validated against a seeded DB with deliberate orphans (purged correctly) under `foreign_keys=ON` inside a transaction (mimicking golang-migrate).
- Full `go build ./...` + `go test ./...` green.

Not tagging a release — happy to fold into the next version bump once reviewed.