### PR TITLE
Fixes manually pushing photos to frame

### DIFF
--- a/backend/internal/handler/device.go
+++ b/backend/internal/handler/device.go
@@ -191,7 +191,7 @@ func (h *DeviceHandler) PushToDevice(c echo.Context) error {
 			imagePath = tempFile
 		} else if img.Source == model.SourceImmich {
 			// Download from Immich to temporary file
-			data, err := h.immichService.DownloadPhoto(img.ImmichAssetID)
+			data, err := h.immichService.DownloadPhoto(img.ExternalID)
 			if err != nil {
 				return respondError(c, http.StatusInternalServerError, fmt.Sprintf("failed to download immich photo: %v", err))
 			}


### PR DESCRIPTION
When manually pushing photo it still uses the ImmichAssetID which is now not filled (blank) and should be using ExternalID